### PR TITLE
Added .fsproj as a valid project extension.

### DIFF
--- a/src/Cake.Incubator.Tests/FilePathExtensionTests.cs
+++ b/src/Cake.Incubator.Tests/FilePathExtensionTests.cs
@@ -35,9 +35,15 @@ namespace Cake.Incubator.Tests
         }
 
         [Fact]
-        public void IsProject_ReturnsTrue_ForProject()
+        public void IsProject_ReturnsTrue_ForCSProject()
         {
             new FilePath("a.csproj").IsProject().Should().BeTrue();
+        }
+
+        [Fact]
+        public void IsProject_ReturnsTrue_ForFSProject()
+        {
+            new FilePath("a.fsproj").IsProject().Should().BeTrue();
         }
 
         [Theory]

--- a/src/Cake.Incubator/FilePathExtensions.cs
+++ b/src/Cake.Incubator/FilePathExtensions.cs
@@ -29,10 +29,11 @@ namespace Cake.Incubator
         /// Checks if the FilePath is a csproj file
         /// </summary>
         /// <param name="filePath">the path to check</param>
-        /// <returns>true if csproj file</returns>
+        /// <returns>true if csproj or fsproj file</returns>
         public static bool IsProject(this FilePath filePath)
         {
-            return filePath.HasExtension && filePath.GetExtension().EqualsIgnoreCase(".csproj");
+            return filePath.HasExtension && 
+                    (filePath.GetExtension().EqualsIgnoreCase(".csproj") || filePath.GetExtension().EqualsIgnoreCase(".fsproj"));
         }
 
         /// <summary>


### PR DESCRIPTION
Previously, the IsProject extension method on FilePath was only returning true if the file
name that was passed to the FilePath had an extension of .csproj. This
has now been extended to recognise .fsproj as a valid project extension.