### PR TITLE
Remove CakeAliasCategory attribute

### DIFF
--- a/src/Cake.Incubator/EnumerableExtensions.cs
+++ b/src/Cake.Incubator/EnumerableExtensions.cs
@@ -12,7 +12,6 @@ namespace Cake.Incubator
     /// <summary>
     /// Several extension methods when using IEnumerable.
     /// </summary>
-    [CakeAliasCategory("Collection Helpers")]
     public static class EnumerableExtensions
     {
         /// <summary>


### PR DESCRIPTION
Remove the `CakeAliasCategory` attribute from the `EnumerableExtensions` class since the class doesn't contain any aliases and it just [clutters the Cake documentation](http://cakebuild.net/dsl/collection-helpers/).