### PR TITLE
Created a new project parser extension method "IsWebApplication".

### DIFF
--- a/src/Cake.Incubator.Tests/CustomProjectParserTests.cs
+++ b/src/Cake.Incubator.Tests/CustomProjectParserTests.cs
@@ -15,6 +15,7 @@ namespace Cake.Incubator.Tests
     {
         private readonly FakeFile validCsProjFile;
         private readonly FakeFile anotherValidFile;
+        private readonly FakeFile validCsProjWebApplicationFile;
         private readonly FakeFile valid2017CsProjFile;
         private readonly FakeFile valid2017CsProjNetcoreFile;
         private readonly FakeFile valid2017CsProjNetstandardFile;
@@ -28,6 +29,7 @@ namespace Cake.Incubator.Tests
             valid2017CsProjNetstandardFile = new FakeFile(Resources.VS2017_CsProj_NetStandard_ValidFile);
             validCsProjConditionalReferenceFile = new FakeFile(Resources.CsProj_ConditionReference_ValidFile);
             anotherValidFile = new FakeFile(Resources.AnotherCSProj);
+            validCsProjWebApplicationFile = new FakeFile(Resources.CsProj_ValidWebApplication);
         }
 
         [Fact]
@@ -127,6 +129,32 @@ namespace Cake.Incubator.Tests
             result.IsType(ProjectType.Unspecified).Should().BeFalse();
             result.IsType(ProjectType.CSharp).Should().BeTrue();
             result.IsType(ProjectType.AspNetMvc1).Should().BeTrue();
+        }
+
+        [Fact]
+        public void IsWebApplication_ReturnsFalse_WhenProjectIsOfTypeLibrary()
+        {
+            // arrange
+            var sut = validCsProjFile.ParseProject("debug");
+
+            // act
+            var webApp = sut.IsWebApplication();
+
+            // assert
+            webApp.ShouldBeEquivalentTo(false);
+        }
+
+        [Fact]
+        public void IsWebApplication_ReturnsFalse_WhenProjectIsOfTypeWebApplication()
+        {
+            // arrange
+            var sut = validCsProjWebApplicationFile.ParseProject("debug");
+
+            // act
+            var webApp = sut.IsWebApplication();
+
+            // assert
+            webApp.ShouldBeEquivalentTo(true);
         }
     }
 

--- a/src/Cake.Incubator.Tests/Resources.Designer.cs
+++ b/src/Cake.Incubator.Tests/Resources.Designer.cs
@@ -123,6 +123,20 @@ namespace Cake.Incubator.Tests {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to &lt;Project ToolsVersion=&quot;12.0&quot; DefaultTargets=&quot;Build&quot; xmlns=&quot;http://schemas.microsoft.com/developer/msbuild/2003&quot;&gt;
+        ///  &lt;Import Project=&quot;$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props&quot; Condition=&quot;Exists(&apos;$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props&apos;)&quot; /&gt;
+        ///  &lt;PropertyGroup&gt;
+        ///    &lt;MinimumVisualStudioVersion&gt;11.0&lt;/MinimumVisualStudioVersion&gt;
+        ///    &lt;Configuration Condition=&quot; &apos;$(Configuration)&apos; == &apos;&apos; &quot;&gt;Debug&lt;/Configuration&gt;
+        ///    &lt;Platform Condition=&quot; &apos;$(Platform)&apos; ==  [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string CsProj_ValidWebApplication {
+            get {
+                return ResourceManager.GetString("CsProj_ValidWebApplication", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to &lt;Project Sdk=&quot;Microsoft.NET.Sdk&quot;&gt;
         ///
         ///  &lt;PropertyGroup&gt;

--- a/src/Cake.Incubator.Tests/Resources.resx
+++ b/src/Cake.Incubator.Tests/Resources.resx
@@ -751,6 +751,61 @@
   &lt;Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" /&gt;
 &lt;/Project&gt;</value>
   </data>
+  <data name="CsProj_ValidWebApplication" xml:space="preserve">
+    <value>&lt;Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003"&gt;
+  &lt;Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" /&gt;
+  &lt;PropertyGroup&gt;
+    &lt;MinimumVisualStudioVersion&gt;11.0&lt;/MinimumVisualStudioVersion&gt;
+    &lt;Configuration Condition=" '$(Configuration)' == '' "&gt;Debug&lt;/Configuration&gt;
+    &lt;Platform Condition=" '$(Platform)' == '' "&gt;AnyCPU&lt;/Platform&gt;
+    &lt;ProjectGuid&gt;{864BC2C5-0E27-47EC-B103-0AC11FE40C5B}&lt;/ProjectGuid&gt;
+    &lt;OutputType&gt;Library&lt;/OutputType&gt;
+    &lt;AppDesignerFolder&gt;Properties&lt;/AppDesignerFolder&gt;
+    &lt;RootNamespace&gt;Cake.Common&lt;/RootNamespace&gt;
+    &lt;AssemblyName&gt;Cake.Common&lt;/AssemblyName&gt;
+    &lt;DefaultLanguage&gt;en-US&lt;/DefaultLanguage&gt;
+    &lt;FileAlignment&gt;512&lt;/FileAlignment&gt;
+    &lt;ProjectTypeGuids&gt;{349c5851-65df-11da-9384-00065b846f21};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}&lt;/ProjectTypeGuids&gt;
+    &lt;TargetFrameworkProfile&gt;Profile111&lt;/TargetFrameworkProfile&gt;
+    &lt;TargetFrameworkVersion&gt;v4.5&lt;/TargetFrameworkVersion&gt;
+  &lt;/PropertyGroup&gt;
+  &lt;PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "&gt;
+    &lt;DebugSymbols&gt;true&lt;/DebugSymbols&gt;
+    &lt;DebugType&gt;full&lt;/DebugType&gt;
+    &lt;Optimize&gt;false&lt;/Optimize&gt;
+    &lt;OutputPath&gt;bin\Debug\&lt;/OutputPath&gt;
+    &lt;DefineConstants&gt;DEBUG;TRACE&lt;/DefineConstants&gt;
+    &lt;ErrorReport&gt;prompt&lt;/ErrorReport&gt;
+    &lt;WarningLevel&gt;4&lt;/WarningLevel&gt;
+  &lt;/PropertyGroup&gt;
+  &lt;PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "&gt;
+    &lt;DebugType&gt;pdbonly&lt;/DebugType&gt;
+    &lt;Optimize&gt;true&lt;/Optimize&gt;
+    &lt;OutputPath&gt;bin\Release\&lt;/OutputPath&gt;
+    &lt;DefineConstants&gt;TRACE&lt;/DefineConstants&gt;
+    &lt;ErrorReport&gt;prompt&lt;/ErrorReport&gt;
+    &lt;WarningLevel&gt;4&lt;/WarningLevel&gt;
+  &lt;/PropertyGroup&gt;
+  &lt;ItemGroup&gt;
+    &lt;Compile Include="Properties\AssemblyInfo.cs" /&gt;
+    &lt;Compile Include="Class1.cs" /&gt;
+    &lt;Content Include="app\**" /&gt;
+  &lt;/ItemGroup&gt;
+  &lt;ItemGroup&gt;
+    &lt;Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL"&gt;
+      &lt;HintPath&gt;..\packages\System.Collections.Immutable.1.1.37\lib\dotnet\System.Collections.Immutable.dll&lt;/HintPath&gt;
+      &lt;Private&gt;True&lt;/Private&gt;
+    &lt;/Reference&gt;
+  &lt;/ItemGroup&gt;
+  &lt;ItemGroup&gt;
+    &lt;ProjectReference Include="..\Cake.Common\Cake.Common.csproj"&gt;
+      &lt;Project&gt;{ABC3F1CB-F84E-43ED-A120-0CCFE344D250}&lt;/Project&gt;
+      &lt;Name&gt;Cake.Common&lt;/Name&gt;
+    &lt;/ProjectReference&gt;
+  &lt;/ItemGroup&gt;
+  &lt;Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" /&gt;
+&lt;/Project&gt;</value>
+  </data>
   <data name="VS2017_CsProj_NetCoreDefault" xml:space="preserve">
     <value>&lt;Project Sdk="Microsoft.NET.Sdk"&gt;
 

--- a/src/Cake.Incubator/ProjectParserExtensions.cs
+++ b/src/Cake.Incubator/ProjectParserExtensions.cs
@@ -37,6 +37,43 @@ namespace Cake.Incubator
         }
 
         /// <summary>
+        /// Checks if the project is a web application.
+        /// </summary>
+        /// <param name="projectParserResult">the parsed project</param>
+        /// <returns>true if the project is a web application</returns>
+        /// <example>
+        /// Check if a parsed project is a web application
+        /// <code>
+        /// CustomParseProjectResult project = ParseProject(new FilePath("test.csproj"), "Release");
+        /// if (project.IsWebApplication()) { ... }
+        /// </code>
+        /// </example>
+        public static bool IsWebApplication(this CustomProjectParserResult projectParserResult)
+        {
+            var webApp = new Guid("349C5851-65DF-11DA-9384-00065B846F21");
+            if (!projectParserResult.ProjectTypeGuids.Any())
+            {
+                return false;
+            }
+
+            foreach (var projectTypeGuid in projectParserResult.ProjectTypeGuids)
+            {
+                bool valid = Guid.TryParse(projectTypeGuid, out Guid result);
+                if (!valid)
+                {
+                    continue;
+                }
+
+                if (result.Equals(webApp))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
         /// Returns the parsed projects output assembly extension
         /// </summary>
         /// <param name="projectParserResult">the parsed project</param>


### PR DESCRIPTION
Related to this issue https://github.com/cake-contrib/Cake.Recipe/issues/134

i required a way to determine if the project being built is a web application or not.
This method works by looking at the Guid in the ProjectTypeGuids array to see if it matches the Web Application Guid.

I've added Unit Tests to cover the new method.