### PR TITLE
GH47: Upgrade to Cake 0.22.0

### DIFF
--- a/src/Cake.Incubator.Tests/Cake.Incubator.Tests.csproj
+++ b/src/Cake.Incubator.Tests/Cake.Incubator.Tests.csproj
@@ -9,7 +9,13 @@
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170425-07" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170425-07" />
+    <PackageReference Include="Cake.Common" Version="0.22.0">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Cake.Core" Version="0.22.0">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Cake.Incubator.Tests/CustomProjectParserTests.cs
+++ b/src/Cake.Incubator.Tests/CustomProjectParserTests.cs
@@ -218,6 +218,12 @@ namespace Cake.Incubator.Tests
 
         public long Length => throw new NotImplementedException();
 
+        public FileAttributes Attributes
+        {
+            get => throw new NotImplementedException();
+            set => throw new NotImplementedException();
+        }
+
         Path IFileSystemInfo.Path => Path;
 
         public bool Exists => throw new NotImplementedException();

--- a/src/Cake.Incubator/Cake.Incubator.csproj
+++ b/src/Cake.Incubator/Cake.Incubator.csproj
@@ -34,20 +34,36 @@
     <DocumentationFile>bin\Release\net45\Cake.Incubator.xml</DocumentationFile>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Cake.Common" Version="0.21.1" />
-    <PackageReference Include="Cake.Core" Version="0.21.1" />
-  </ItemGroup>
-
   <ItemGroup Condition="'$(TargetFramework)' == 'net46'">
     <PackageReference Include="System.Collections.Specialized">
       <Version>4.3.0</Version>
+    </PackageReference>
+    <PackageReference Include="Cake.Common" Version="0.22.0">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Cake.Core" Version="0.22.0">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
+    <PackageReference Include="Cake.Common" Version="0.21.1">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Cake.Core" Version="0.21.1">
+      <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.6'">
     <PackageReference Include="System.Collections.Specialized">
       <Version>4.3.0</Version>
+    </PackageReference>
+    <PackageReference Include="Cake.Common" Version="0.22.0">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Cake.Core" Version="0.22.0">
+      <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
 


### PR DESCRIPTION
* fixes #47
* keeps 4.5 support by referencing Cake 0.22.1 for 4.5
* make Cake references private to not get installed with addin as Cake.Core/Common is shipped with Cake runner