### PR TITLE
Fix: patch IsWebApplication

### DIFF
--- a/src/Cake.Incubator/ProjectParserExtensions.cs
+++ b/src/Cake.Incubator/ProjectParserExtensions.cs
@@ -134,7 +134,7 @@ namespace Cake.Incubator
         {
             if (projectParserResult.IsNetFramework)
             {
-                if (!projectParserResult.ProjectTypeGuids.Any())
+                if (projectParserResult.ProjectTypeGuids.IsNullOrEmpty())
                 {
                     return false;
                 }


### PR DESCRIPTION
for a VS2017 Library project, IsWebApplication extension throws exception due to ProjectTypeGuids beeing null. This PR fixes that issue.

Can provide a repo to reproduce said error in case it's needed