### PR TITLE
Implementing file globbing in ParseProject alias.

### DIFF
--- a/src/Cake.Incubator/ProjectPathExtensions.cs
+++ b/src/Cake.Incubator/ProjectPathExtensions.cs
@@ -21,5 +21,17 @@ namespace Cake.Incubator
         {
             return new ProjectPath(System.IO.Path.Combine(basePath.FullPath, path));
         }
+
+        public static string GetRelativeProjectFilePath(this ProjectPath filePath, DirectoryPath projectRootDirectoryPath)
+        {
+            
+            if (filePath == null || string.IsNullOrEmpty(filePath.Path))
+                return string.Empty;
+
+            if ((projectRootDirectoryPath == null || string.IsNullOrEmpty(projectRootDirectoryPath.FullPath)))
+                return filePath.Path;
+
+            return filePath.Path.Replace(projectRootDirectoryPath.FullPath, string.Empty).TrimStart(new char[] { '\\', '/' });
+        }
     }
 }


### PR DESCRIPTION
Please review my changes for file globbing in the parse project alias.
These changes are in support of issue: [Project Parser does not support Wildcards. #2183](https://github.com/cake-build/cake/issues/2183).

**Explanation of Changes:**
The structure of the project parsing code in Cake.Incubator is considerably different from that which is in the current build of Cake.  It seems as though it is moving towards handling most internal functionality as extensions.  The changes that i made, I made trying to keep this structure in mind.  

To construct a Cake.Core.IO.Globber object, you need to pass in an IFileSystem and an ICakeEnvironment interface. With everything now, being broken down into extension methods (vs. having a ProjectParser object), I went looking for the least disruptive way to get a Globber object down to where I needed it -`ProjectParserExtensions.GetNetFrameworkMSBuildProjects() `.  That was to modify `ProjectParserExtensions.ParseProjectFile` to accept arguments of IFileSystem and ICakeEnvironment at the end of its argument list.  In my opinion it would have been more useful to have some class which retains references to these objects and passed that around.  But again,  I didn't want to be that disruptive with this change.  Or at least, maybe it would be more useful to have a `class ProjectParseParams` that is accepted by these extension methods (and contains 'configuration', 'platform', 'filesystem', etc.) ? Again, I didn't want to disturb the direction of this module too much.

That said, I am open to discussion and suggestions around these changes.

