### PR TITLE
Check for 'Update' attribute on files referenced in MSBuild projects

### DIFF
--- a/src/Cake.Incubator/ProjectParserExtensions.cs
+++ b/src/Cake.Incubator/ProjectParserExtensions.cs
@@ -870,8 +870,9 @@ namespace Cake.Incubator
                           element.Name != ns + ProjectXElement.BootstrapperPackage &&
                           element.Name != ns + ProjectXElement.ProjectReference &&
                           element.Name != ns + ProjectXElement.Service
-                    from include in element.Attributes("Include")
-                    let value = include.Value
+                    from attribute in element.Attributes("Include")
+                        .Union( from update in element.Attributes("Update") select update)
+                    let value = attribute.Value
                     where !string.IsNullOrEmpty(value)
                     let filePath = rootPath.CombineWithProjectPath(value)
                     select new CustomProjectFile


### PR DESCRIPTION
See: [Project parser does not handle the new 'Update' attribute available for .NET Core projects. #2184](https://github.com/cake-build/cake/issues/2184)