### PR TITLE
cake 0.28 update

### DIFF
--- a/nuspec/nuget/Cake.Incubator.nuspec
+++ b/nuspec/nuget/Cake.Incubator.nuspec
@@ -16,9 +16,6 @@
     <tags>Cake Build Script Extensions Project Solution</tags>
   </metadata>
   <files>
-    <file src="netstandard1.6\Cake.Incubator.dll" target="lib/netstandard1.6" />
-    <file src="netstandard1.6\Cake.Incubator.xml" target="lib/netstandard1.6" />
-    <file src="netstandard1.6\Cake.Incubator.pdb" target="lib/netstandard1.6" />
     <file src="netstandard2.0\Cake.Incubator.dll" target="lib/netstandard2.0" />
     <file src="netstandard2.0\Cake.Incubator.xml" target="lib/netstandard2.0" />
     <file src="netstandard2.0\Cake.Incubator.pdb" target="lib/netstandard2.0" />

--- a/src/Cake.Incubator.Tests/Cake.Incubator.Tests.csproj
+++ b/src/Cake.Incubator.Tests/Cake.Incubator.Tests.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net462</TargetFrameworks>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Cake.Common" Version="0.27.1" />
-    <PackageReference Include="Cake.Core" Version="0.27.1" />
+    <PackageReference Include="Cake.Common" Version="0.28.0" />
+    <PackageReference Include="Cake.Core" Version="0.28.0" />
     <PackageReference Include="FakeItEasy" Version="4.5.1" />
     <PackageReference Include="FakeItEasy.Analyzer.CSharp" Version="4.5.1" />
     <PackageReference Include="FluentAssertions" Version="5.3.0" />

--- a/src/Cake.Incubator.Tests/GlobbingExtensionsTests.cs
+++ b/src/Cake.Incubator.Tests/GlobbingExtensionsTests.cs
@@ -27,7 +27,7 @@ namespace Cake.Incubator.Tests
             environment = new FakeCakeEnvironment();
             globber = new Globber(fileSystem, environment);
             context = new CakeContext(fileSystem, environment, globber, new NullLog(), A.Dummy<ICakeArguments>(),
-                A.Dummy<IProcessRunner>(), A.Dummy<IRegistry>(), A.Dummy<IToolLocator>());
+                A.Dummy<IProcessRunner>(), A.Dummy<IRegistry>(), A.Dummy<IToolLocator>(), A.Dummy<ICakeDataService>());
         }
 
         [Fact(Skip = "FakeEnvironment needs fixed")]

--- a/src/Cake.Incubator.Tests/StringExtensionsTests.cs
+++ b/src/Cake.Incubator.Tests/StringExtensionsTests.cs
@@ -19,34 +19,5 @@ namespace Cake.Incubator.Tests
         {
             "A".EqualsIgnoreCase("B").Should().BeFalse();
         }
-
-        //[Theory]
-        //[InlineData(null)]
-        //[InlineData("")]
-        //[InlineData(" ")]
-        //public void HasCondition_ReturnsFalseIfNullOrEmpty(string condition)
-        //{
-        //    condition.HasTargetFrameworkCondition().Should().BeFalse();
-        //}
-
-        //[Theory]
-        //[InlineData("'$(TargetFramework)'==")]
-        //[InlineData("'$(TargetFramework)' ==")]
-        //[InlineData("'$(TargetFramework)'  ==")]
-        //[InlineData(" '$(TargetFramework)'==  ")]
-        //public void HasCondition_ReturnsTrue(string condition)
-        //{
-        //    condition.HasTargetFrameworkCondition().Should().BeTrue();
-        //}
-
-        //[Theory]
-        //[InlineData("'$(TargetFramework)'=='net45' ", "net45")]
-        //[InlineData("'$(TargetFramework)' =='net462'", "net462")]
-        //[InlineData("'$(TargetFramework)'  == 'netstandard1_6' ", "netstandard1_6")]
-        //[InlineData(" '$(TargetFramework)'==  'bobbins'  ", "bobbins")]
-        //public void GetCondition_ReturnsExpected(string condition, string expected)
-        //{
-        //    condition.GetConditionTargetFramework().Should().Be(expected);
-        //}
     }
 }

--- a/src/Cake.Incubator/Cake.Incubator.csproj
+++ b/src/Cake.Incubator/Cake.Incubator.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard1.6</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Version>0.1.0</Version>
     <Description>Provides useful extensions and additional aliases for Cake.Build scripts</Description>
@@ -16,34 +16,17 @@
   <PropertyGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
     <DefineConstants>NETSTANDARD2_0;</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)'=='netstandard1.6'">
-    <DefineConstants>NETSTANDARD1_6;</DefineConstants>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard2.0|AnyCPU'">
     <DocumentationFile>bin\Release\netstandard2.0\Cake.Incubator.xml</DocumentationFile>
     <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>
     <Optimize>false</Optimize>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard1.6|AnyCPU'">
-    <DocumentationFile>bin\Release\netstandard1.6\Cake.Incubator.xml</DocumentationFile>
-    <DebugType>full</DebugType>
-    <DebugSymbols>true</DebugSymbols>
-    <Optimize>false</Optimize>
-  </PropertyGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.6'">
-    <PackageReference Include="Cake.Common" Version="0.22.0">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="Cake.Core" Version="0.22.0">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Cake.Common" Version="0.27.1">
+    <PackageReference Include="Cake.Common" Version="0.28.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Cake.Core" Version="0.27.1">
+    <PackageReference Include="Cake.Core" Version="0.28.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/src/Cake.Incubator/LoggingExtensions.cs
+++ b/src/Cake.Incubator/LoggingExtensions.cs
@@ -84,11 +84,9 @@ namespace Cake.Incubator
             {
                 var propertyType = descriptor.PropertyType;
                 var value = descriptor.GetValue(obj);
-#if NETSTANDARD1_6
-                var enumerableType = propertyType.GetTypeInfo().GetInterface("IEnumerable");
-#else
+
                 var enumerableType = propertyType.GetInterface("IEnumerable");
-#endif
+
                 if (enumerableType != null && propertyType != typeof(string))
                 {
                     ProcessEnumerable(value, dump, descriptor);


### PR DESCRIPTION
Fixes #77 
I think it also fixes #71 
Removed NETSTANDARD1_6 references.
Cleaned up uses of the compiler directive NETSTANDARD1_6
Fixed GlobbingExtensionsTests for core 0.28 compatibility
Removed commented-out section of StringExtensionsTests - since it was showing up on my search for NETSTANDARD1_6

Cake 0.28 ready.