### PR TITLE
Add dotnet core project guid and comparison 

### DIFF
--- a/src/Cake.Incubator/ProjectTypes.cs
+++ b/src/Cake.Incubator/ProjectTypes.cs
@@ -27,6 +27,7 @@ namespace Cake.Incubator
         DeploymentSetup,
         DeploymentSmartDeviceCab,
         DistributedSystem,
+        DotNetCore,
         Dynamics2012AxCsharpInAot,
         FSharp,
         JSharp,
@@ -97,6 +98,7 @@ namespace Cake.Incubator
         public const string DeploymentSetup = "{978C614F-708E-4E1A-B201-565925725DBA}";
         public const string DeploymentSmartDeviceCab = "{AB322303-2255-48EF-A496-5904EB18DA55}";
         public const string DistributedSystem = "{F135691A-BF7E-435D-8960-F99683D2D49C}";
+        public const string DotNetCore = "{9A19103F-16F7-4668-BE54-9A1E7A4F7556}";
         public const string Dynamics2012AxCsharpInAot = "{BF6F8E12-879D-49E7-ADF0-5503146B24B8}";
         public const string FSharp = "{F2A71F9B-5D33-465A-A702-920D77279786}";
         public const string JSharp = "{E6FDF86B-F3D1-11D4-8576-0002A516ECE8}";

--- a/src/Cake.Incubator/SolutionParserExtensions.cs
+++ b/src/Cake.Incubator/SolutionParserExtensions.cs
@@ -99,6 +99,7 @@ namespace Cake.Incubator
             { ProjectType.DeploymentMergeModule, ProjectTypes.DeploymentMergeModule },
             { ProjectType.DeploymentSetup, ProjectTypes.DeploymentSetup },
             { ProjectType.DeploymentSmartDeviceCab, ProjectTypes.DeploymentSmartDeviceCab },
+            { ProjectType.DotNetCore, ProjectTypes.DotNetCore },
             { ProjectType.DistributedSystem, ProjectTypes.DistributedSystem },
             { ProjectType.Dynamics2012AxCsharpInAot, ProjectTypes.Dynamics2012AxCsharpInAot },
             { ProjectType.FSharp, ProjectTypes.FSharp },


### PR DESCRIPTION
Docs on this are a bit sparse, this is the project gid used whenever a new dot net core library is created.

The same GUID is used for asp.net core, console apps, and libraries, so I believe it's replacing the `CSharp` guid going down the line.

Some references: 
https://github.com/dotnet/project-system/issues/3079

https://github.com/dotnet/project-system/blob/696f786d4d0a4d72dfa5d7897612dd6825059b37/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/Packaging/CSharpProjectSystemPackage.cs#L35
