### PR TITLE
(#116) added net5.0+ TFM to match IsNetCore

### DIFF
--- a/src/Cake.Incubator.Tests/CustomProjectParserTests.cs
+++ b/src/Cake.Incubator.Tests/CustomProjectParserTests.cs
@@ -345,6 +345,19 @@ namespace Cake.Incubator.Tests
             project.IsNetCore.Should().BeTrue();
             project.IsNetStandard.Should().BeFalse();
         }
+        
+        [Fact]
+        public void ForTfm_net60ios_With_Version_IsNetCore_IsSet()
+        {
+            var projectString = ProjectFileHelpers.GetNetCoreProjectWithString(
+                "<PropertyGroup><TargetFramework>net6.0-ios14.0</TargetFramework></PropertyGroup>");
+            var file = new FakeFile(projectString);
+
+            var project = file.ParseProjectFile("Release");
+            project.IsNetFramework.Should().BeFalse();
+            project.IsNetCore.Should().BeTrue();
+            project.IsNetStandard.Should().BeFalse();
+        }
     }
 
     internal class TestProjectParserResult : CustomProjectParserResult

--- a/src/Cake.Incubator.Tests/CustomProjectParserTests.cs
+++ b/src/Cake.Incubator.Tests/CustomProjectParserTests.cs
@@ -280,6 +280,45 @@ namespace Cake.Incubator.Tests
             // assert
             webApp.Should().Be(@"bin\custom\");
         }
+        
+        [Fact]
+        public void ForTfm_net451_IsNetFramework_IsSet()
+        {
+            var projectString = ProjectFileHelpers.GetNetCoreProjectWithString(
+                "<PropertyGroup><TargetFramework>net451</TargetFramework></PropertyGroup>");
+            var file = new FakeFile(projectString);
+
+            var project = file.ParseProjectFile("Release");
+            project.IsNetFramework.Should().BeTrue();
+            project.IsNetCore.Should().BeFalse();
+            project.IsNetStandard.Should().BeFalse();
+        }
+
+        [Fact]
+        public void ForTfm_netcoreapp31_IsNetCore_IsSet()
+        {
+            var projectString = ProjectFileHelpers.GetNetCoreProjectWithString(
+                "<PropertyGroup><TargetFramework>netcoreapp3.1</TargetFramework></PropertyGroup>");
+            var file = new FakeFile(projectString);
+
+            var project = file.ParseProjectFile("Release");
+            project.IsNetFramework.Should().BeFalse();
+            project.IsNetCore.Should().BeTrue();
+            project.IsNetStandard.Should().BeFalse();
+        }
+        
+        [Fact]
+        public void ForTfm_netstandard20_IsNetStandard_IsSet()
+        {
+            var projectString = ProjectFileHelpers.GetNetCoreProjectWithString(
+                "<PropertyGroup><TargetFramework>netstandard2.0</TargetFramework></PropertyGroup>");
+            var file = new FakeFile(projectString);
+
+            var project = file.ParseProjectFile("Release");
+            project.IsNetFramework.Should().BeFalse();
+            project.IsNetCore.Should().BeFalse();
+            project.IsNetStandard.Should().BeTrue();
+        }
     }
 
     internal class TestProjectParserResult : CustomProjectParserResult

--- a/src/Cake.Incubator.Tests/CustomProjectParserTests.cs
+++ b/src/Cake.Incubator.Tests/CustomProjectParserTests.cs
@@ -319,6 +319,32 @@ namespace Cake.Incubator.Tests
             project.IsNetCore.Should().BeFalse();
             project.IsNetStandard.Should().BeTrue();
         }
+        
+        [Fact]
+        public void ForTfm_net50_IsNetCore_IsSet()
+        {
+            var projectString = ProjectFileHelpers.GetNetCoreProjectWithString(
+                "<PropertyGroup><TargetFramework>net5.0</TargetFramework></PropertyGroup>");
+            var file = new FakeFile(projectString);
+
+            var project = file.ParseProjectFile("Release");
+            project.IsNetFramework.Should().BeFalse();
+            project.IsNetCore.Should().BeTrue();
+            project.IsNetStandard.Should().BeFalse();
+        }
+        
+        [Fact]
+        public void ForTfm_net50windows_IsNetCore_IsSet()
+        {
+            var projectString = ProjectFileHelpers.GetNetCoreProjectWithString(
+                "<PropertyGroup><TargetFramework>net5.0-windows</TargetFramework></PropertyGroup>");
+            var file = new FakeFile(projectString);
+
+            var project = file.ParseProjectFile("Release");
+            project.IsNetFramework.Should().BeFalse();
+            project.IsNetCore.Should().BeTrue();
+            project.IsNetStandard.Should().BeFalse();
+        }
     }
 
     internal class TestProjectParserResult : CustomProjectParserResult

--- a/src/Cake.Incubator.Tests/NetCoreProjectParserExtensionsTests.cs
+++ b/src/Cake.Incubator.Tests/NetCoreProjectParserExtensionsTests.cs
@@ -38,7 +38,6 @@ namespace Cake.Incubator.Tests
         [InlineData("netcoreapp1.0")]
         [InlineData("netcoreapp1.1")]
         [InlineData("netcoreapp2.0")]
-        [InlineData("netcoreappX.X")]
         public void ParseProject_SetsIsNetCore(string coreTarget)
         {
             var file = new FakeFile(ProjectFileHelpers.GetNetCoreProjectWithElement("TargetFramework", coreTarget));
@@ -49,7 +48,6 @@ namespace Cake.Incubator.Tests
         [InlineData("netstandard1.0")]
         [InlineData("netstandard1.1")]
         [InlineData("netstandard2.0")]
-        [InlineData("netstandardX.X")]
         public void ParseProject_SetsIsNetStandard(string coreTarget)
         {
             var file = new FakeFile(ProjectFileHelpers.GetNetCoreProjectWithElement("TargetFramework", coreTarget));

--- a/src/Cake.Incubator/Project/ProjectParserExtensions.cs
+++ b/src/Cake.Incubator/Project/ProjectParserExtensions.cs
@@ -35,7 +35,7 @@ namespace Cake.Incubator.Project
         private static readonly Regex NetCoreTargetFrameworkRegex = new Regex("^netcoreapp\\d+\\.\\d+$", parseOptions);
         private static readonly Regex NetStandardTargetFrameworkRegex = new Regex("^netstandard\\d+\\.\\d+$", parseOptions);
         private static readonly Regex NetFrameworkTargetFrameworkRegex = new Regex("^net\\d+$", parseOptions);
-        private static readonly Regex Net5PlusTargetFrameworkRegex = new Regex("^net\\d+\\.\\d+(-\\w+)?$", parseOptions);
+        private static readonly Regex Net5PlusTargetFrameworkRegex = new Regex("^net\\d+\\.\\d+(-[\\w.]+)?$", parseOptions);
         
         /// <summary>
         /// Checks if the project is a library

--- a/src/Cake.Incubator/Project/ProjectParserExtensions.cs
+++ b/src/Cake.Incubator/Project/ProjectParserExtensions.cs
@@ -31,10 +31,12 @@ namespace Cake.Incubator.Project
     [CakeAliasCategory("MSBuild Resource")]
     public static class ProjectParserExtensions
     {
-        private static readonly Regex NetCoreTargetFrameworkRegex = new Regex("([Nn][Ee][Tt])([Cc])\\w+", RegexOptions.Compiled);
-        private static readonly Regex NetStandardTargetFrameworkRegex = new Regex("([Nn][Ee][Tt])([Ss])\\w+", RegexOptions.Compiled);
-        private static readonly Regex NetFrameworkTargetFrameworkRegex = new Regex("([Nn][Ee][Tt][0-9*])\\w+", RegexOptions.Compiled);
-
+        private const RegexOptions parseOptions = RegexOptions.Compiled | RegexOptions.IgnoreCase;
+        private static readonly Regex NetCoreTargetFrameworkRegex = new Regex("^netcoreapp\\d+\\.\\d+$", parseOptions);
+        private static readonly Regex NetStandardTargetFrameworkRegex = new Regex("^netstandard\\d+\\.\\d+$", parseOptions);
+        private static readonly Regex NetFrameworkTargetFrameworkRegex = new Regex("^net\\d+$", parseOptions);
+        private static readonly Regex Net5PlusTargetFrameworkRegex = new Regex("^net\\d+\\.\\d+(-\\w+)?$", parseOptions);
+        
         /// <summary>
         /// Checks if the project is a library
         /// </summary>
@@ -948,7 +950,7 @@ namespace Cake.Incubator.Project
             var treatSpecificWarningsAsErrors = document.GetFirstElementValue(ProjectXElement.TreatSpecificWarningsAsErrors, config, platform)?.SplitIgnoreEmpty(';') ?? new string[0];
             var defineConstants = document.GetFirstElementValue(ProjectXElement.DefineConstants, config, platform)?.SplitIgnoreEmpty(';').Where(x => !x.StartsWith("$"))?.ToArray() ?? new string[0];
             var targets = document.GetTargets();
-            var isNetCore = targetFrameworks.Any(x => NetCoreTargetFrameworkRegex.IsMatch(x));
+            var isNetCore = targetFrameworks.Any(x => NetCoreTargetFrameworkRegex.IsMatch(x) || Net5PlusTargetFrameworkRegex.IsMatch(x));
             var isNetStandard = targetFrameworks.Any(x => NetStandardTargetFrameworkRegex.IsMatch(x));
             var isNetFramework = targetFrameworks.Any(x => NetFrameworkTargetFrameworkRegex.IsMatch(x));
 


### PR DESCRIPTION
## Description
* Simplified the RegEx to parse TFM
* added a RegEx to match `net5.0`+ TFM as `netCore`

## Related Issue
fixes #116

## Motivation and Context
#116

## How Has This Been Tested?
I added unit tests for the existing RegEx and the added one.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
