### PR TITLE
(maint) exclude Cake.Common and Cake.Testing from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,7 @@ updates:
     ignore:
       - dependency-name: "Cake.Core"
       - dependency-name: "Cake.Common"
+      - dependency-name: "Cake.Testing"
     labels: [ ]
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     target-branch: "develop"
     ignore:
       - dependency-name: "Cake.Core"
+      - dependency-name: "Cake.Common"
+    labels: [ ]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -16,3 +18,4 @@ updates:
     commit-message:
       prefix: "(maint)"
     target-branch: "develop"
+    labels: [ "Build" ]


### PR DESCRIPTION
so it does not auto-update it.

Also, removed the default labels on dependabot PRs for nuget
dependencies and set the default label to "Build" for gh-action
dependencies.

To prevent other PRs like https://github.com/cake-contrib/Cake.Incubator/pull/156.