### PR TITLE
(GH-161) updated CodeQL workflow to current best practice

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,11 +13,12 @@ on:
     branches: [develop]
   schedule:
     - cron: '0 15 * * 6'
+  workflow_dispatch:
 
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     strategy:
       fail-fast: false
@@ -30,14 +31,15 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2.3.4
+      uses: actions/checkout@v2
       with:
         fetch-depth: 0
 
-    # If this run was triggered by a pull request event, then checkout
-    # the head of the pull request instead of the merge commit.
-    - run: git checkout HEAD^2
-      if: ${{ github.event_name == 'pull_request' }}
+    - name: Cache Tools
+      uses: actions/cache@v2
+      with:
+        path: tools
+        key: ${{ runner.os }}-tools-${{ hashFiles('recipe.cake') }}
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
@@ -49,8 +51,25 @@ jobs:
         # Prefix the list here with "+" to use these queries and those in the config file.
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
-    - run: ./build.ps1
-      shell: pwsh
+    - name: Build project
+      uses: cake-build/cake-action@v1
+      with:
+        script-path: recipe.cake
+        target: DotNetCore-Build
+        cake-version: 0.38.5
+        cake-bootstrap: true
+      env:
+        COMPlus_DbgEnableMiniDump: 1
+        COMPlus_DbgMiniDumpType: 1
+        COMPlus_DbgMiniDumpName: BuildArtifacts/coredump.dmp
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1
+
+    - name: Upload CoreDump
+      uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        if-no-files-found: warn
+        name: CoreDump
+        path: BuildArtifacts/coredump.dmp


### PR DESCRIPTION
With the addition of creating a core-dump
when the dotnet process will again end unexpectedly
with the famous exit code 139.

fixes #161