### PR TITLE
Respect the AppendTargetFrameworkToOutputPath setting to compilation output

### DIFF
--- a/src/Cake.Incubator.Tests/Cake.Incubator.Tests.csproj
+++ b/src/Cake.Incubator.Tests/Cake.Incubator.Tests.csproj
@@ -10,10 +10,12 @@
     <None Remove="sampleprojects\CsProj_AbsolutePath.xml" />
     <None Remove="sampleprojects\CsProj_ConditionReference_ValidFile.xml" />
     <None Remove="sampleprojects\CsProj_InvalidFile.xml" />
+    <None Remove="sampleprojects\CsProj_NoAppendTargetFramework.xml" />
     <None Remove="sampleprojects\CsProj_ValidFile.xml" />
     <None Remove="sampleprojects\CsProj_ValidMSTestFile.xml" />
     <None Remove="sampleprojects\CsProj_ValidWebApplication.xml" />
     <None Remove="sampleprojects\CsProj_ValidXUnitTestFile.xml" />
+    <None Remove="sampleprojects\CsProj_AppendTargetFramework.xml" />
     <None Remove="sampleprojects\VS2017_CsProj_NetCoreDefault.xml" />
     <None Remove="sampleprojects\VS2017_CsProj_NetStandard_ValidFile.xml" />
     <None Remove="sampleprojects\VS2017_CsProj_ValidFile.xml" />
@@ -24,12 +26,14 @@
     <EmbeddedResource Include="sampleprojects\CsProjValidFSUnitTestFile.xml" />
     <EmbeddedResource Include="sampleprojects\CsProjValidNUnitTestFile.xml" />
     <EmbeddedResource Include="sampleprojects\CsProj_AbsolutePath.xml" />
+    <EmbeddedResource Include="sampleprojects\CsProj_NoAppendTargetFramework.xml" />
     <EmbeddedResource Include="sampleprojects\CsProj_ConditionReference_ValidFile.xml" />
     <EmbeddedResource Include="sampleprojects\CsProj_InvalidFile.xml" />
     <EmbeddedResource Include="sampleprojects\CsProj_ValidFile.xml" />
     <EmbeddedResource Include="sampleprojects\CsProj_ValidMSTestFile.xml" />
     <EmbeddedResource Include="sampleprojects\CsProj_ValidWebApplication.xml" />
     <EmbeddedResource Include="sampleprojects\CsProj_ValidXUnitTestFile.xml" />
+    <EmbeddedResource Include="sampleprojects\CsProj_AppendTargetFramework.xml" />
     <EmbeddedResource Include="sampleprojects\VS2017_CsProj_NetCoreDefault.xml" />
     <EmbeddedResource Include="sampleprojects\VS2017_CsProj_NetStandard_ValidFile.xml" />
     <EmbeddedResource Include="sampleprojects\VS2017_CsProj_ValidFile.xml" />

--- a/src/Cake.Incubator.Tests/CustomProjectParserTests.cs
+++ b/src/Cake.Incubator.Tests/CustomProjectParserTests.cs
@@ -51,6 +51,8 @@ namespace Cake.Incubator.Tests
         private readonly FakeFile valid2017CsProjNetstandardFile;
         private readonly FakeFile validCsProjConditionalReferenceFile;
         private readonly FakeFile validCsProjWithAbsoluteFilePaths;
+        private readonly FakeFile validCsProjAppendTargetFrameworkFile;
+        private readonly FakeFile validCsProjNoAppendTargetFrameworkFile;
         private readonly FakeFileSystem fs;
 
         public CustomProjectParserTests()
@@ -63,6 +65,8 @@ namespace Cake.Incubator.Tests
             validCsProjConditionalReferenceFile = fs.CreateFakeFile("CsProj_ConditionReference_ValidFile".SafeLoad());
             validCsProjWebApplicationFile = fs.CreateFakeFile("CsProj_ValidWebApplication".SafeLoad());
             validCsProjWithAbsoluteFilePaths = fs.CreateFakeFile("CsProj_AbsolutePath".SafeLoad());
+            validCsProjAppendTargetFrameworkFile = fs.CreateFakeFile("CsProj_AppendTargetFramework".SafeLoad());
+            validCsProjNoAppendTargetFrameworkFile = fs.CreateFakeFile("CsProj_NoAppendTargetFramework".SafeLoad());
         }
 
         [Fact]
@@ -106,6 +110,24 @@ namespace Cake.Incubator.Tests
             result.OutputType.Should().Be("Library");
             var paths = result.GetAssemblyFilePaths();
             paths.Should().ContainSingle(x => x.FullPath.EqualsIgnoreCase("bin/debug/cake.common.dll"));
+        }
+
+        [Fact]
+        public void CustomProjectParser_RespectNoAppendTargetFrameworkToOutputPath_ForDebugConfig()
+        {
+            var result = validCsProjNoAppendTargetFrameworkFile.ParseProjectFile("debug");
+
+            result.Configuration.Should().Be("debug");
+            result.OutputPath.ToString().Should().Be("bin/debug");
+        }
+
+        [Fact]
+        public void CustomProjectParser_RespectAppendTargetFrameworkToOutputPath_ForDebugConfig()
+        {
+            var result = validCsProjAppendTargetFrameworkFile.ParseProjectFile("debug");
+
+            result.Configuration.Should().Be("debug");
+            result.OutputPath.ToString().Should().Be("bin/debug/net48");
         }
 
 

--- a/src/Cake.Incubator.Tests/sampleprojects/CsProj_AppendTargetFramework.xml
+++ b/src/Cake.Incubator.Tests/sampleprojects/CsProj_AppendTargetFramework.xml
@@ -1,0 +1,8 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net48</TargetFramework>
+		<Deterministic>False</Deterministic>
+		<AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>
+		<OutputType>Exe</OutputType>
+	</PropertyGroup>
+</Project>

--- a/src/Cake.Incubator.Tests/sampleprojects/CsProj_NoAppendTargetFramework.xml
+++ b/src/Cake.Incubator.Tests/sampleprojects/CsProj_NoAppendTargetFramework.xml
@@ -1,0 +1,8 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net48</TargetFramework>
+		<Deterministic>False</Deterministic>
+		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+		<OutputType>Exe</OutputType>
+	</PropertyGroup>
+</Project>

--- a/src/Cake.Incubator/Project/ProjectXElement.cs
+++ b/src/Cake.Incubator/Project/ProjectXElement.cs
@@ -12,6 +12,7 @@ namespace Cake.Incubator.Project
     {
         internal const string Aliases = "Aliases";
         internal const string AllowUnsafeBlocks = "AllowUnsafeBlocks";
+        internal const string AppendTargetFrameworkToOutputPath = "AppendTargetFrameworkToOutputPath";
         internal const string ApplicationIcon = "ApplicationIcon";
         internal const string AssemblyName = "AssemblyName";
         internal const string AssemblyOriginatorKeyFile = "AssemblyOriginatorKeyFile";

--- a/src/Cake.Incubator/XDocumentExtensions.cs
+++ b/src/Cake.Incubator/XDocumentExtensions.cs
@@ -53,9 +53,11 @@ namespace Cake.Incubator.XDocumentExtensions
             if (!AssertExtensions.AssertExtensions.IsNullOrEmpty(platform) && !platform.EqualsIgnoreCase("AnyCPU")) template += $"{platform}/";
             if (!AssertExtensions.AssertExtensions.IsNullOrEmpty(config)) template += $"{config}/";
 
-            return targetFrameworks.IsNullOrEmpty()
-                ? new[] {rootDirectoryPath.Combine(template)}
-                : targetFrameworks.Select(x => rootDirectoryPath.Combine(template).Combine(x)).ToArray();
+            var shouldAppendTargetFramework = !targetFrameworks.IsNullOrEmpty() && (document.GetFirstElementValue(ProjectXElement.AppendTargetFrameworkToOutputPath) ?? "true") == "true";
+
+            return shouldAppendTargetFramework
+                ? targetFrameworks.Select(x => rootDirectoryPath.Combine(template).Combine(x)).ToArray()
+                : new[] { rootDirectoryPath.Combine(template) };
         }
 
         /// <summary>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adds a check on the AppendTargetFrameworkToOutputPath property to avoid incorrectly appending the target framework to the output path

## Description
<!--- Describe your changes in detail -->
Adds a check on AppendTargetFrameworkToOutputPath via `document.GetFirstElementValue` to `XDocumentExtensions.GetOutputPaths` and then factors this in when deciding if the target framework should be appended to the output paths.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #174 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Currently the value of AppendTargetFrameworkToOutputPath is ignored, thus when it is set to anything other than the default (which is true) the output paths will be incorrect.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Two additional tests: 
- if AppendTargetFrameworkToOutputPath is set to true, the target framework is appended
- if AppendTargetFrameworkToOutputPath is set to false, the target framework is *not* appended

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
