### PR TITLE
Fix append target framework with output path

### DIFF
--- a/src/Cake.Incubator.Tests/Cake.Incubator.Tests.csproj
+++ b/src/Cake.Incubator.Tests/Cake.Incubator.Tests.csproj
@@ -11,11 +11,13 @@
     <None Remove="sampleprojects\CsProj_ConditionReference_ValidFile.xml" />
     <None Remove="sampleprojects\CsProj_InvalidFile.xml" />
     <None Remove="sampleprojects\CsProj_NoAppendTargetFramework.xml" />
+    <None Remove="sampleprojects\CsProj_NoAppendTargetFrameworkWithOutputPath.xml" />
     <None Remove="sampleprojects\CsProj_ValidFile.xml" />
     <None Remove="sampleprojects\CsProj_ValidMSTestFile.xml" />
     <None Remove="sampleprojects\CsProj_ValidWebApplication.xml" />
     <None Remove="sampleprojects\CsProj_ValidXUnitTestFile.xml" />
     <None Remove="sampleprojects\CsProj_AppendTargetFramework.xml" />
+    <None Remove="sampleprojects\CsProj_AppendTargetFrameworkWithOutputPath.xml" />
     <None Remove="sampleprojects\VS2017_CsProj_NetCoreDefault.xml" />
     <None Remove="sampleprojects\VS2017_CsProj_NetStandard_ValidFile.xml" />
     <None Remove="sampleprojects\VS2017_CsProj_ValidFile.xml" />
@@ -27,6 +29,7 @@
     <EmbeddedResource Include="sampleprojects\CsProjValidNUnitTestFile.xml" />
     <EmbeddedResource Include="sampleprojects\CsProj_AbsolutePath.xml" />
     <EmbeddedResource Include="sampleprojects\CsProj_NoAppendTargetFramework.xml" />
+    <EmbeddedResource Include="sampleprojects\CsProj_NoAppendTargetFrameworkWithOutputPath.xml" />
     <EmbeddedResource Include="sampleprojects\CsProj_ConditionReference_ValidFile.xml" />
     <EmbeddedResource Include="sampleprojects\CsProj_InvalidFile.xml" />
     <EmbeddedResource Include="sampleprojects\CsProj_ValidFile.xml" />
@@ -34,6 +37,7 @@
     <EmbeddedResource Include="sampleprojects\CsProj_ValidWebApplication.xml" />
     <EmbeddedResource Include="sampleprojects\CsProj_ValidXUnitTestFile.xml" />
     <EmbeddedResource Include="sampleprojects\CsProj_AppendTargetFramework.xml" />
+    <EmbeddedResource Include="sampleprojects\CsProj_AppendTargetFrameworkWithOutputPath.xml" />
     <EmbeddedResource Include="sampleprojects\VS2017_CsProj_NetCoreDefault.xml" />
     <EmbeddedResource Include="sampleprojects\VS2017_CsProj_NetStandard_ValidFile.xml" />
     <EmbeddedResource Include="sampleprojects\VS2017_CsProj_ValidFile.xml" />

--- a/src/Cake.Incubator.Tests/CustomProjectParserTests.cs
+++ b/src/Cake.Incubator.Tests/CustomProjectParserTests.cs
@@ -53,6 +53,8 @@ namespace Cake.Incubator.Tests
         private readonly FakeFile validCsProjWithAbsoluteFilePaths;
         private readonly FakeFile validCsProjAppendTargetFrameworkFile;
         private readonly FakeFile validCsProjNoAppendTargetFrameworkFile;
+        private readonly FakeFile validCsProjAppendTargetFrameworkOutputPathFile;
+        private readonly FakeFile validCsProjNoAppendTargetFrameworkOutputPathFile;
         private readonly FakeFileSystem fs;
 
         public CustomProjectParserTests()
@@ -67,6 +69,8 @@ namespace Cake.Incubator.Tests
             validCsProjWithAbsoluteFilePaths = fs.CreateFakeFile("CsProj_AbsolutePath".SafeLoad());
             validCsProjAppendTargetFrameworkFile = fs.CreateFakeFile("CsProj_AppendTargetFramework".SafeLoad());
             validCsProjNoAppendTargetFrameworkFile = fs.CreateFakeFile("CsProj_NoAppendTargetFramework".SafeLoad());
+            validCsProjAppendTargetFrameworkOutputPathFile = fs.CreateFakeFile("CsProj_AppendTargetFrameworkWithOutputPath".SafeLoad());
+            validCsProjNoAppendTargetFrameworkOutputPathFile = fs.CreateFakeFile("CsProj_NoAppendTargetFrameworkWithOutputPath".SafeLoad());
         }
 
         [Fact]
@@ -116,6 +120,24 @@ namespace Cake.Incubator.Tests
         public void CustomProjectParser_RespectNoAppendTargetFrameworkToOutputPath_ForDebugConfig()
         {
             var result = validCsProjNoAppendTargetFrameworkFile.ParseProjectFile("debug");
+
+            result.Configuration.Should().Be("debug");
+            result.OutputPath.ToString().Should().Be("bin/debug");
+        }
+
+        [Fact]
+        public void CustomProjectParser_RespectAppendTargetFrameworkOutputPathToOutputPath_ForDebugConfig()
+        {
+            var result = validCsProjAppendTargetFrameworkOutputPathFile.ParseProjectFile("debug");
+
+            result.Configuration.Should().Be("debug");
+            result.OutputPath.ToString().Should().Be("bin/debug/net48");
+        }
+
+        [Fact]
+        public void CustomProjectParser_RespectNoAppendTargetFrameworkOutputPathToOutputPath_ForDebugConfig()
+        {
+            var result = validCsProjNoAppendTargetFrameworkOutputPathFile.ParseProjectFile("debug");
 
             result.Configuration.Should().Be("debug");
             result.OutputPath.ToString().Should().Be("bin/debug");

--- a/src/Cake.Incubator.Tests/sampleprojects/CsProj_AppendTargetFrameworkWithOutputPath.xml
+++ b/src/Cake.Incubator.Tests/sampleprojects/CsProj_AppendTargetFrameworkWithOutputPath.xml
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net48</TargetFramework>
+		<Deterministic>False</Deterministic>
+		<AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>
+		<OutputPath>Local</OutputPath>
+		<OutputType>Exe</OutputType>
+	</PropertyGroup>
+</Project>

--- a/src/Cake.Incubator.Tests/sampleprojects/CsProj_NoAppendTargetFrameworkWithOutputPath.xml
+++ b/src/Cake.Incubator.Tests/sampleprojects/CsProj_NoAppendTargetFrameworkWithOutputPath.xml
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net48</TargetFramework>
+		<Deterministic>False</Deterministic>
+		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+		<OutputPath>Local</OutputPath>
+		<OutputType>Exe</OutputType>
+	</PropertyGroup>
+</Project>

--- a/src/Cake.Incubator/XDocumentExtensions.cs
+++ b/src/Cake.Incubator/XDocumentExtensions.cs
@@ -39,21 +39,20 @@ namespace Cake.Incubator.XDocumentExtensions
                     return condition.GetConditionalConfigPlatform().EqualsIgnoreCase($"{config}|{platform}");
                 })?.Value;
 
+            var shouldAppendTargetFramework = !targetFrameworks.IsNullOrEmpty() && (document.GetFirstElementValue(ProjectXElement.AppendTargetFrameworkToOutputPath) ?? "true") == "true";
+
             // specific output path is specified in project, overrides convention
             if (!string.IsNullOrWhiteSpace(outputPathOverride))
             {
-                return targetFrameworks.IsNullOrEmpty()
-                    ? new[] {rootDirectoryPath.Combine(outputPathOverride)}
-                    : targetFrameworks.Select(
-                        x => rootDirectoryPath.Combine(outputPathOverride).Combine(x)).ToArray();
+                return shouldAppendTargetFramework
+                    ? targetFrameworks.Select(x => rootDirectoryPath.Combine(outputPathOverride).Combine(x)).ToArray()
+                    : new[] {rootDirectoryPath.Combine(outputPathOverride)};
             }
 
             // use conventions, skip null or empty props
             var template = "bin/";
             if (!AssertExtensions.AssertExtensions.IsNullOrEmpty(platform) && !platform.EqualsIgnoreCase("AnyCPU")) template += $"{platform}/";
             if (!AssertExtensions.AssertExtensions.IsNullOrEmpty(config)) template += $"{config}/";
-
-            var shouldAppendTargetFramework = !targetFrameworks.IsNullOrEmpty() && (document.GetFirstElementValue(ProjectXElement.AppendTargetFrameworkToOutputPath) ?? "true") == "true";
 
             return shouldAppendTargetFramework
                 ? targetFrameworks.Select(x => rootDirectoryPath.Combine(template).Combine(x)).ToArray()


### PR DESCRIPTION
Respect the AppendTargetFrameworkToOutputPath setting for compilation output.

This fixes the target framework being added to the output path when OutputPath is set, and AppendTargetFrameworkToOutputPath is false.